### PR TITLE
quick fix for failed location

### DIFF
--- a/lib/android_interface.rb
+++ b/lib/android_interface.rb
@@ -27,8 +27,8 @@ module AndroidInterface
   def location_coordinates(opts={})
     result = DROID.getLastKnownLocation["result"]
     refresh_location if (result.nil? || opts["refresh"])
-    data = result["gps"] || result["network"] || result["passive"]
-    latitude, longitude = data["latitude"], data["longitude"]
+    data = result["gps"] || result["network"] || result["passive"] || nil
+    latitude, longitude = data["latitude"], data["longitude"] if data
     longitude ? [latitude, longitude] : false
   end
 


### PR DESCRIPTION
Quick fix to allow app to run on my Samsung Vibrant.

Using v0.1, I was getting no method error for [] on nil inside location_coordinates() at startup.

I'm new to android development, so i'm not sure how much help i'll be. :)
Samsung Vibrant
OS: 2.1
